### PR TITLE
Build more macos python versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,11 @@ matrix:
     env: PYTHON=python3 PIP=pip3 HOMEBREW_NO_AUTO_UPDATE=1
   - os: osx
     language: generic
-    osx_image: xcode9.3
+    osx_image: xcode12.2
+    env: PYTHON=python3 PIP=pip3 HOMEBREW_NO_AUTO_UPDATE=1  
+  - os: osx
+    language: generic
+    osx_image: xcode10.3
     env: PYTHON=python3 PIP=pip3 HOMEBREW_NO_AUTO_UPDATE=1  
   - os: windows
     language: bash

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,11 @@ matrix:
   - os: osx
     language: generic
     osx_image: xcode8.3
-    env: PYTHON=python3 PIP=pip3 HOMEBREW_NO_AUTO_UPDATE=1    
+    env: PYTHON=python3 PIP=pip3 HOMEBREW_NO_AUTO_UPDATE=1
+  - os: osx
+    language: generic
+    osx_image: xcode9.3
+    env: PYTHON=python3 PIP=pip3 HOMEBREW_NO_AUTO_UPDATE=1  
   - os: windows
     language: bash
     env: PYTHON_VERSION=3.7.8 PATH=/C/Python37:/C/Python37/Scripts:$PATH


### PR DESCRIPTION
Until now we support only python 3.6 that's old. Trying to add 3.7, 3.8, 3.9.